### PR TITLE
Support new Wagtail 2.0 module paths

### DIFF
--- a/wagtailblocks_cards/blocks.py
+++ b/wagtailblocks_cards/blocks.py
@@ -3,7 +3,10 @@ from django.apps import apps
 from django.template.loader import render_to_string
 from django.contrib.staticfiles.templatetags.staticfiles import static
 
-from wagtail.wagtailcore.blocks import ListBlock
+try:
+    from wagtail.core.blocks import ListBlock
+except ImportError:  # fallback for Wagtail <2.0
+    from wagtail.wagtailcore.blocks import ListBlock
 
 
 class CardsBlock(ListBlock):


### PR DESCRIPTION
This PR updates where the ListBlock is imported from to support thew new Wagtail 2.0 module paths.